### PR TITLE
Add loading slice of state. Remove clearing of state on search for 

### DIFF
--- a/app/frontend/src/actions/search_actions.js
+++ b/app/frontend/src/actions/search_actions.js
@@ -6,6 +6,7 @@ import { toggleLoader } from './loader_actions';
 export const RECEIVE_SEARCH_DATA = "RECEIVE_SEARCH_DATA";
 export const RECEIVE_WATSON_DATA = "RECEIVE_WATSON_DATA";
 export const RECEIVE_TWITTER_DATA = "RECEIVE_TWITTER_DATA";
+export const RECEIVE_LAST_SEARCH = "RECEIVE_LAST_SEARCH";
 
 export const receiveSearchData = searchData => ({
   type: RECEIVE_SEARCH_DATA,
@@ -42,6 +43,10 @@ export const receiveSearch = searchData => dispatch => {
   SearchAPIUtil.saveSearch(searchData)
     .then(searchData => dispatch(receiveSearchData(searchData)))
     .then(() => dispatch(fetchTwitterData(searchData)))
-    .then(res => dispatch(fetchWatsonData(res.twitterData.data.allText)))
+    .then(res => {
+      localStorage.tweets = JSON.stringify(res.twitterData.data.allTweets);
+      dispatch(fetchWatsonData(res.twitterData.data.allText))
+      }
+    )
     .then(() => dispatch(toggleLoader(false)));
 };

--- a/app/frontend/src/components/dashboard/dashboard_container.jsx
+++ b/app/frontend/src/components/dashboard/dashboard_container.jsx
@@ -7,8 +7,8 @@ import BarGraph from './dashboard_graphs/bar_graph';
 import ScatterGraph from './dashboard_graphs/scatter_graph';
 import Loader from 'react-loader-spinner';
 import { toggleLoader } from '../../actions/loader_actions';
+import TweetList from './tweet_list_container';
 // import { watchFile } from 'fs';
-import TweetList from './tweet_list';
 // import '../../css/dashboard.css';
 
 class DashboardContainer extends Component {
@@ -48,7 +48,7 @@ class DashboardContainer extends Component {
       let tweetTones = watsonSentenceTones[i].tones;
       for (let j = 0; j < allTweets.length; j++) {
         let tweetText = allTweets[j].fullText;
-        let tweetTime = allTweets[j].tweetTime
+        let tweetTime = allTweets[j].tweetTime;
         if (tweetText.includes(tweetSubstring)) {
           res.push([tweetTime, tweetTones]);
         }
@@ -57,10 +57,6 @@ class DashboardContainer extends Component {
     return res;
   }
 
-  componentDidMount() {
-    this.props.toggleLoader(true);
-  }
-  
   componentWillMount() {
     this.getGraphData();
   }
@@ -366,16 +362,6 @@ class DashboardContainer extends Component {
   }
 
   render() {
-    //replace later with data passed in through container
-    // if (!Object.keys(this.state.radarGraphData).length) {
-    //   return (
-    //     <Loader 
-    //       type="Puff"
-    //       color="#00BFFF"
-    //       height="100"	
-    //       width="100" />   
-    //   );
-    console.log(this.props.loader);
     if (this.props.loader) {
       return (
         <Loader 
@@ -385,7 +371,6 @@ class DashboardContainer extends Component {
           width="100" />   
       );
     } else {
-      // debugger
       return (
         <div>
           <div className="dashboard-container">
@@ -397,7 +382,8 @@ class DashboardContainer extends Component {
                 <LineGraph graphData={this.state.lineGraphData} />
                 <RadarGraph graphData={this.state.radarGraphData} />
                 <DoughnutGraph graphData={this.state.doughnutGraphData} />
-                <TweetList tweets={this.props.allTweets} />
+                <TweetList />
+                {/* <TweetList tweets={this.props.allTweets} /> */}
               </div>
             </div>
           </div>
@@ -410,7 +396,6 @@ class DashboardContainer extends Component {
 
 
 const msp = state => {
-  // debugger
   return {
     allTweets: state.entities.tweets.allTweets,
     watsonDocTones: state.entities.watson.documentTones,

--- a/app/frontend/src/components/dashboard/tweet_list.jsx
+++ b/app/frontend/src/components/dashboard/tweet_list.jsx
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-class TweetList extends Component{
+class TweetList extends React.Component {
     constructor(props){
         super(props);
         this.tweets = this.props.tweets;
@@ -13,7 +13,6 @@ class TweetList extends Component{
     }
 
     render(){
-        // debugger;
         let tweets;
         if (this.tweets !== undefined){
             tweets = 
@@ -24,29 +23,19 @@ class TweetList extends Component{
                         </li>
                     ) 
                 })
+        } else if (localStorage.tweets !== undefined) { // use tweets that have been previously stored in localStorage from prior search
+            tweets = JSON.parse(localStorage.getItem('tweets')).map((tweet, idx) => {
+                return (
+                    <li key={idx} className="tweet-index">
+                        {tweet.fullText}
+                    </li>
+                )
+            })
         }
 
-        // if (this.state.tweets !== undefined){
-        //     this.tweetList = 
-        //         this.state.tweets.map((tweet,idx) => {
-        //             return (
-        //                 <li key={idx} className="tweet-index"> 
-        //                     {tweet.fullText}
-        //                 </li>
-        //             ) 
-        //         })
-        // }
-        // debugger
-        // const tweets = this.tweets.map((tweet, idx) => {
-        //     return (
-        //         <li key={idx} className="tweet-index">
-        //             {tweet.fullText}
-        //         </li>
-        //     )
-        // })
         return (
             <div>
-                <ul>
+                <ul className="tweets">
                     {tweets}
                 </ul>
             </div>

--- a/app/frontend/src/components/dashboard/tweet_list_container.jsx
+++ b/app/frontend/src/components/dashboard/tweet_list_container.jsx
@@ -1,0 +1,13 @@
+import TweetList from './tweet_list';
+import { connect } from 'react-redux';
+import { fetchTwitterData } from '../../actions/search_actions';
+
+const msp = state => ({
+    tweets: state.entities.tweets.allTweets
+});
+
+const mdp = dispatch => ({
+    fetchTwitterData: searchData => dispatch(fetchTwitterData(searchData))
+});
+
+export default connect(msp, mdp)(TweetList);

--- a/app/frontend/src/components/navbar/navbar.jsx
+++ b/app/frontend/src/components/navbar/navbar.jsx
@@ -41,12 +41,6 @@ class NavBar extends React.Component {
     e.preventDefault();
     this.props.history.push('/profile');
   }
-
-            // if (this.props.location.pathname === '/dashboard') {
-            //   window.location.reload();
-            // } else {
-            //   this.props.history.push('/dashboard');
-            // }
         
   toHome() {
     return (e) => {
@@ -55,10 +49,11 @@ class NavBar extends React.Component {
   }
       
   handleKeyPress(e) {
+    // debugger
     if (e.key === 'Enter') {
       // console.log(this.state.search);
       this.props.search(this.state.search);
-      this.setState({search: ""});
+      // this.setState({search: ""});
       if (this.props.location.pathname !== '/dashboard') {
         this.props.history.push('/dashboard');
       }

--- a/app/frontend/src/reducers/tweets_reducer.js
+++ b/app/frontend/src/reducers/tweets_reducer.js
@@ -1,6 +1,6 @@
 import { RECEIVE_TWITTER_DATA } from '../actions/search_actions';
 
-const tweetsReducer = (oldState = {}, action) => {
+const tweetsReducer = (oldState={}, action) => {
   Object.freeze(oldState);
   let newState = Object.assign({}, oldState);
 


### PR DESCRIPTION
better UI (now shows keeps previous search term in local state after search - due to prior resets, the search was returning 400 status on searches made immediately after a search was initially made). Store last set of tweets in localStorage to render on refresh.